### PR TITLE
Point at redirected URL.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,9 @@ runs:
 
     - name: Setup DDEV
       uses: ddev/github-action-setup-ddev@v1
+      with:
+        # XXX: The default `https://ddev.com/install.sh` started 504ing.
+        installScriptUrl: "https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev.sh"
 
     - name: Install unupdated site
       shell: bash


### PR DESCRIPTION
ddev.com apparently started blocking GHA?

At least, saw 504s for a couple of attempted runs:
- https://github.com/discoverygarden/wmc-drupal/actions/runs/29032768925/job/86169626308#step:2:191
- https://github.com/discoverygarden/wmc-drupal/actions/runs/29032768925/job/86171605279#step:2:191

<details>

<summary>snippet of logs</summary>

Formatting is somewhat off, but should get the message across, I think:

```
Run ddev/github-action-setup-ddev@v1
  with:
    ddevDir: .
    autostart: true
    version: latest
    installScriptUrl: https://ddev.com/install.sh
  env:
    AWS_DEFAULT_REGION: us-east-1
    AWS_REGION: us-east-1
    AWS_ACCESS_KEY_ID: ***
    AWS_SECRET_ACCESS_KEY: ***
    AWS_SESSION_TOKEN: ***
Run curl -fsSL --retry 3 --retry-max-time 60 --retry-connrefused \
  curl -fsSL --retry 3 --retry-max-time 60 --retry-connrefused \
       -o /tmp/install_ddev.sh \
       "https://ddev.com/install.sh"
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    AWS_DEFAULT_REGION: us-east-1
    AWS_REGION: us-east-1
    AWS_ACCESS_KEY_ID: ***
    AWS_SECRET_ACCESS_KEY: ***
    AWS_SESSION_TOKEN: ***
Run if [[ 'latest' != 'latest' ]]; then
  if [[ 'latest' != 'latest' ]]; then
    VERSION_ARG="vlatest"
    echo "Installing DDEV version: ${VERSION_ARG}"
  else
    VERSION_ARG=""
    echo "Installing latest DDEV version"
  fi
  
  # Make installation script executable
  chmod +x /tmp/install_ddev.sh
  
  /tmp/install_ddev.sh ${VERSION_ARG}
  ddev config global --instrumentation-opt-in=false --omit-containers=ddev-ssh-agent
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    AWS_DEFAULT_REGION: us-east-1
    AWS_REGION: us-east-1
    AWS_ACCESS_KEY_ID: ***
    AWS_SECRET_ACCESS_KEY: ***
    AWS_SESSION_TOKEN: ***
Installing latest DDEV version
curl: (22) The requested URL returned error: 504
Failed to get find latest release
Error: Process completed with exit code 107.
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the setup step to use a more reliable install source, reducing intermittent timeouts during DDEV installation.
  * This should make the action more dependable and less likely to fail during environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->